### PR TITLE
Add support for optional templates in context menu, instead of hardcoded ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# JetBrains
+.idea

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
   },
   "homepage": "https://github.com/mixmaxhq/electron-editor-context-menu#readme",
   "dependencies": {
+    "lodash.clonedeep": "^4.3.0",
     "lodash.defaults": "^4.0.1",
-    "lodash.isempty": "^4.1.2"
+    "lodash.isarray": "^4.0.0",
+    "lodash.isempty": "^4.1.2",
+    "lodash.isfunction": "^3.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/mixmaxhq/electron-editor-context-menu#readme",
   "dependencies": {
-    "underscore": "^1.8.3"
+    "lodash.defaults": "^4.0.1",
+    "lodash.isempty": "^4.1.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,68 @@
 var noop = function(){};
 var defaults = require('lodash.defaults');
 var isEmpty = require('lodash.isEmpty');
+var isFunction = require('lodash.isFunction');
+var isArray = require('lodash.isArray');
+var cloneDeep = require('lodash.cloneDeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
 
+
+var DEFAULT_MAIN_TPL = [{
+  label: 'Undo',
+  role: 'undo'
+}, {
+  label: 'Redo',
+  role: 'redo'
+}, {
+  type: 'separator'
+}, {
+  label: 'Cut',
+  role: 'cut'
+}, {
+  label: 'Copy',
+  role: 'copy'
+}, {
+  label: 'Paste',
+  role: 'paste'
+}, {
+  label: 'Paste and Match Style',
+  click: function() {
+    BrowserWindow.getFocusedWindow().webContents.pasteAndMatchStyle();
+  }
+}, {
+  label: 'Select All',
+  role: 'selectall'
+}];
+
+var DEFAULT_SUGGESTIONS_TPL = [
+  {
+    label: 'No suggestions',
+    click: noop
+  }, {
+    type: 'separator'
+  }
+];
+
+/**
+ * if passed a function, invoke it and pass a clone of the default (for safe mutations)
+ * if passed an array, use as is
+ * otherwise, just return a clone of the default
+ * @param val {*}
+ * @param defaultVal {Array}
+ * @returns {Array}
+ */
+function getTemplate(val, defaultVal) {
+  if(isFunction(val)) {
+    return val(cloneDeep(defaultVal));
+  }
+  else if(isArray(val)) {
+    return val;
+  }
+  else {
+    return cloneDeep(defaultVal);
+  }
+}
 
 /**
  * Builds a context menu suitable for showing in a text editor.
@@ -13,54 +72,23 @@ var Menu = require('electron').Menu;
  *     misspelled, `false` if it is spelled correctly or is not text.
  *   @property {Array<String>=[]} spellingSuggestions - An array of suggestions
  *     to show to correct the misspelling. Ignored if `isMisspelled` is `false`.
- * @param {Array} mainTemplate - Optional. The template of always-present menu items.
- * @param {Array} suggestionsTemplate - Optional. The template of spelling suggestion items.
+ * @param {Function|Array} mainTemplate - Optional. If it's an array, use as is.
+ *    If it's a function, used to customize the template of always-present menu items.
+ *    Receives the default template as a parameter. Should return a template.
+ * @param {Function|Array} suggestionsTemplate - Optional. If it's an array, use as is.
+ *    If it's a function, used to customize the template of spelling suggestion items.
+ *    Receives the default suggestions template as a parameter. Should return a template.
  * @return {Menu}
  */
 var buildEditorContextMenu = function(selection, mainTemplate, suggestionsTemplate) {
-  var DEFAULT_MAIN_TPL = [{
-    label: 'Undo',
-    role: 'undo'
-  }, {
-    label: 'Redo',
-    role: 'redo'
-  }, {
-    type: 'separator'
-  }, {
-    label: 'Cut',
-    role: 'cut'
-  }, {
-    label: 'Copy',
-    role: 'copy'
-  }, {
-    label: 'Paste',
-    role: 'paste'
-  }, {
-    label: 'Paste and Match Style',
-    click: function() {
-      BrowserWindow.getFocusedWindow().webContents.pasteAndMatchStyle();
-    }
-  }, {
-    label: 'Select All',
-    role: 'selectall'
-  }];
-
-  var DEFAULT_SUGGESTIONS_TPL = [
-    {
-      label: 'No suggestions',
-      click: noop
-    }, {
-      type: 'separator'
-    }
-  ];
 
   selection = defaults({}, selection, {
     isMisspelled: false,
     spellingSuggestions: []
   });
 
-  var template = mainTemplate ? mainTemplate : DEFAULT_MAIN_TPL;
-  var suggestionsTpl = suggestionsTemplate ? suggestionsTemplate : DEFAULT_SUGGESTIONS_TPL;
+  var template = getTemplate(mainTemplate, DEFAULT_MAIN_TPL);
+  var suggestionsTpl = getTemplate(suggestionsTemplate, DEFAULT_SUGGESTIONS_TPL);
 
   if (selection.isMisspelled) {
     var suggestions = selection.spellingSuggestions;

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,8 @@ var Menu = require('electron').Menu;
  *     misspelled, `false` if it is spelled correctly or is not text.
  *   @property {Array<String>=[]} spellingSuggestions - An array of suggestions
  *     to show to correct the misspelling. Ignored if `isMisspelled` is `false`.
- * @param {Array} mainTemplate - optional
- * @param {Object} suggestionsTemplate - optional
+ * @param {Array} mainTemplate - Optional. The template of always-present menu items.
+ * @param {Array} suggestionsTemplate - Optional. The template of spelling suggestion items.
  * @return {Menu}
  */
 var buildEditorContextMenu = function(selection, mainTemplate, suggestionsTemplate) {


### PR DESCRIPTION
First of all, thanks for making this, it definitely saved me some time and frustration :smile_cat:. 

I have a use case where I need to both internationalize my context menu and have some different options than what was provided by default in this library. So I added support for an optional `mainTemplate` and `suggestionsTemplate` parameter to accomplish that end. If those params aren't provided, the defaults originally created by you are used instead. 

I also swapped out underscore for lodash so I could get just the needed functions to keep the library a little slimmer (and thus make the final package slimmer too). 

So everything is backwards compatible and you get some more flexibility. Let me know what you think and if you'd like to see some changes. Thanks!