### PR TITLE
Fix: case insensitive module resolution breaks in compiled electron apps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 var noop = function(){};
 var defaults = require('lodash.defaults');
-var isEmpty = require('lodash.isEmpty');
-var isFunction = require('lodash.isFunction');
-var isArray = require('lodash.isArray');
-var cloneDeep = require('lodash.cloneDeep');
+var isEmpty = require('lodash.isempty');
+var isFunction = require('lodash.isfunction');
+var isArray = require('lodash.isarray');
+var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
 


### PR DESCRIPTION
OSX and Windows have case-insensitive file systems and when I run node from a terminal both `require('lodash.isEmpty')` and `require('lodash.isempty')` work. The official module names however are all lowercase and for whatever reason, when compiled using electron-builder, `require('lodash.isEmpty')` fails. I wish I could offer better reasons why it fails -- I haven't been able to find an answer yet as to why node's behavior changes when it's compiled in electron. 