### PR TITLE
Encapsulate Electron's remote module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ npm install electron-editor-context-menu --save
 ```js
 // In the renderer process:
 var remote = require('electron').remote;
-// `remote.require` since `Menu` is a main-process module.
-var buildEditorContextMenu = remote.require('electron-editor-context-menu');
+var buildEditorContextMenu = require('electron-editor-context-menu');
 
 window.addEventListener('contextmenu', function(e) {
   // Only show the context menu in text editors.
@@ -80,4 +79,3 @@ Copyright 2016 Mixmax, Inc., licensed under the MIT License.
 * 1.1.1 Fix compatibility with electron-builder
 * 1.1.0 Add the ability to customize the main template and the suggestions template.
 * 1.0.0 Initial release.
-

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ var isFunction = require('lodash.isfunction');
 var isArray = require('lodash.isarray');
 var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
-var Menu = require('electron').Menu;
+var Menu = require('electron').remote.Menu;
 
 
 var DEFAULT_MAIN_TPL = [{


### PR DESCRIPTION
Not sure why the module currently opted to be referenced with Electron's `remote` module instead of encapsulating that inside this module itself.

I run into a problem when I bundle everything together into one large JS file with Webpack -- since Electron and it's modules are defined as External in Webpack, this package will not get included automatically in the bundle and is instead treated as another External.

I'm currently solving this by simply moving the remote module to where the script tries to reference Electron's `menu` so that I can just use `electron-editor-context-menu` directly, and everything just gets bundled and runs as it should.
